### PR TITLE
docs: Key generation not working in Safari

### DIFF
--- a/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
+++ b/apps/docs/pages/guides/auth/social-login/auth-apple.mdx
@@ -67,6 +67,11 @@ When developing with Expo, you can test Sign in with Apple via the Expo Go app, 
     Use this tool to generate a new Apple client secret. No keys leave your browser!
 
     </Admonition>
+    <Admonition>
+
+    Generate Secret Key doesn't work in the Safari browser. Try any other browser (chrome)!
+
+    </Admonition>
 
     <AppleSecretGenerator />
 


### PR DESCRIPTION
fixed: #20301

Task:
Added warning, that Key generation not working in Safari 